### PR TITLE
upload a new file version if already present

### DIFF
--- a/src/main/java/com/ibm/garage/box/service/BoxService.java
+++ b/src/main/java/com/ibm/garage/box/service/BoxService.java
@@ -25,6 +25,16 @@ public interface BoxService {
 
   BoxFolderInfoVo getFolder(String folderId) throws IOException;
 
+  /**
+   * Upload a file to the desired Box folder. If a file with the same name already exists, upload a
+   * new version.
+   * 
+   * @param folderId - the ID of the Box folder where we want to upload the file
+   * @param name - the name of the uploaded file
+   * @param filePath - the file path to the uploaded file
+   * @return the ID of the uploaded file
+   * @throws IOException
+   */
   String upload(String folderId, String name, String filePath) throws IOException;
 
   void download(String fileId, String filePath) throws IOException;


### PR DESCRIPTION
Closes #7 

Updated the upload command to upload a new file version in case we already have a file with the same name in the Box folder.
In order to upload a new version, the file name needs to identical (case sensitive) to the existing file. In case the folder already contains a file with the desired name, but different letter case, the call will fail (same behavior observed when using the Box UI).

#### Changelog

**Changed**

- Updated the upload service

#### Testing / Reviewing

Try to upload the same file multiple times. The operation should succeed and each time you should have a new file version. 
